### PR TITLE
2D periodic alpha shapes added - if a bounding box is passed, it shou…

### DIFF
--- a/include/diode/diode.h
+++ b/include/diode/diode.h
@@ -15,6 +15,9 @@
 
 #include <CGAL/Delaunay_triangulation_2.h>
 
+#include <CGAL/Periodic_2_Delaunay_triangulation_2.h>
+#include <CGAL/Periodic_2_Delaunay_triangulation_traits_2.h>
+
 #include <CGAL/version_macros.h>
 
 #if (CGAL_VERSION_MAJOR == 4 && CGAL_VERSION_MINOR >= 11) || (CGAL_VERSION_MAJOR > 4)
@@ -49,6 +52,12 @@ struct AlphaShapes
 
 template<class Points, class SimplexCallback>
 void fill_alpha_shapes2d(const Points& points, const SimplexCallback& add_simplex);
+
+template<class Points, class SimplexCallback>
+void fill_periodic_alpha_shapes2d(const Points& points, const SimplexCallback& add_simplex,
+                                std::array<double, 3> from, std::array<double, 3> to);
+
+
 
 }
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -52,3 +52,13 @@ def test_sorted():
         f = diode.fill_alpha_shapes(points)
 
         assert(is_sorted(f, key = lambda x: (x[1], len(x[0]))))
+
+
+def test_periodic():
+    np.random.seed(42)
+    for dim in [2,3]:
+        points = np.random.random((1000,dim))
+        f = diode.fill_periodic_alpha_shapes(points)
+
+        assert(is_sorted(f, key = lambda x: (x[1], len(x[0]))))
+    


### PR DESCRIPTION
2D periodic alpha shapes added in the same way as 2D alpha shapes - the call in diode.cpp calls the correct function by the dimension of the input. Note that the bounding box is still 3dD with the last coordinate ignored - this lets there remain a single function for periodic alpha shapes. 

The function itself in diode.hpp is a near copy of the 2d alpha shape code - with added work to make sure the filtration values are correctly computed (for simplices which "wrap around").

Possible improvements - renaming variables in the file for clarity, and currently there is no check that the result is simplicial (that it exists as a 1-sheeted triangulation). 