### PR TITLE
Expose alpha-shape attachment info via with_attachment kwarg

### DIFF
--- a/bindings/python/diode.cpp
+++ b/bindings/python/diode.cpp
@@ -36,9 +36,26 @@ struct AddSimplex
     Simplices* result;
 };
 
-void sort_filtration(AddSimplex::Simplices& filtration)
+struct AddSimplexWithAttachment
 {
-    using Simplex = AddSimplex::Simplices::value_type;
+    using Simplices = std::vector<std::tuple<std::vector<unsigned>, double, std::vector<unsigned>>>;
+
+        AddSimplexWithAttachment(Simplices* result_): result(result_)     {}
+
+    template<unsigned long D>
+    void operator()(const std::array<unsigned, D>& vertices, double a, const std::vector<unsigned>& tau) const
+    {
+        std::vector<unsigned> verts(vertices.begin(), vertices.end());
+        result->emplace_back(verts, a, tau);
+    }
+
+    Simplices* result;
+};
+
+template<class Simplices>
+void sort_filtration(Simplices& filtration)
+{
+    using Simplex = typename Simplices::value_type;
     std::sort(filtration.begin(), filtration.end(), [](const Simplex& x, const Simplex& y)
     {
         auto xv = std::get<1>(x);
@@ -57,54 +74,97 @@ void sort_filtration(AddSimplex::Simplices& filtration)
     });
 }
 
-AddSimplex::Simplices
-fill_alpha_shape(py::array a, bool exact)
+py::object
+fill_alpha_shape(py::array a, bool exact, bool with_attachment)
 {
     if (a.ndim() != 2)
         throw std::runtime_error("Unknown input dimension: can only process 2D arrays");
 
     if (a.shape()[1] == 3)
     {
-        if (a.dtype().is(py::dtype::of<float>()))
+        if (with_attachment)
         {
-            AddSimplex::Simplices filtration;
-            if (exact)
-                diode::AlphaShapes<true>::fill_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration));
+            AddSimplexWithAttachment::Simplices filtration;
+            if (a.dtype().is(py::dtype::of<float>()))
+            {
+                if (exact)
+                    diode::AlphaShapes<true>::fill_alpha_shapes_with_attachment(ArrayWrapper<float>(a), AddSimplexWithAttachment(&filtration));
+                else
+                    diode::AlphaShapes<false>::fill_alpha_shapes_with_attachment(ArrayWrapper<float>(a), AddSimplexWithAttachment(&filtration));
+            }
+            else if (a.dtype().is(py::dtype::of<double>()))
+            {
+                if (exact)
+                    diode::AlphaShapes<true>::fill_alpha_shapes_with_attachment(ArrayWrapper<double>(a), AddSimplexWithAttachment(&filtration));
+                else
+                    diode::AlphaShapes<false>::fill_alpha_shapes_with_attachment(ArrayWrapper<double>(a), AddSimplexWithAttachment(&filtration));
+            }
             else
-                diode::AlphaShapes<false>::fill_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration));
-            return filtration;
-        }
-        else if (a.dtype().is(py::dtype::of<double>()))
-        {
-            AddSimplex::Simplices filtration;
-            if (exact)
-                diode::AlphaShapes<true>::fill_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration));
-            else
-                diode::AlphaShapes<false>::fill_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration));
-            return filtration;
+                throw std::runtime_error("Unknown array dtype");
+            return py::cast(filtration);
         }
         else
-            throw std::runtime_error("Unknown array dtype");
+        {
+            AddSimplex::Simplices filtration;
+            if (a.dtype().is(py::dtype::of<float>()))
+            {
+                if (exact)
+                    diode::AlphaShapes<true>::fill_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration));
+                else
+                    diode::AlphaShapes<false>::fill_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration));
+            }
+            else if (a.dtype().is(py::dtype::of<double>()))
+            {
+                if (exact)
+                    diode::AlphaShapes<true>::fill_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration));
+                else
+                    diode::AlphaShapes<false>::fill_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration));
+            }
+            else
+                throw std::runtime_error("Unknown array dtype");
+            return py::cast(filtration);
+        }
     } else if (a.shape()[1] == 2)
     {
-        AddSimplex::Simplices filtration;
-        if (a.dtype().is(py::dtype::of<float>()))
-            diode::fill_alpha_shapes2d(ArrayWrapper<float>(a), AddSimplex(&filtration));
-        else if (a.dtype().is(py::dtype::of<double>()))
-            diode::fill_alpha_shapes2d(ArrayWrapper<double>(a), AddSimplex(&filtration));
+        if (with_attachment)
+        {
+            AddSimplexWithAttachment::Simplices filtration;
+            if (a.dtype().is(py::dtype::of<float>()))
+                diode::fill_alpha_shapes2d_with_attachment(ArrayWrapper<float>(a), AddSimplexWithAttachment(&filtration));
+            else if (a.dtype().is(py::dtype::of<double>()))
+                diode::fill_alpha_shapes2d_with_attachment(ArrayWrapper<double>(a), AddSimplexWithAttachment(&filtration));
+            else
+                throw std::runtime_error("Unknown array dtype");
+            sort_filtration(filtration);
+            return py::cast(filtration);
+        }
         else
-            throw std::runtime_error("Unknown array dtype");
-
-        sort_filtration(filtration);
-        return filtration;
+        {
+            AddSimplex::Simplices filtration;
+            if (a.dtype().is(py::dtype::of<float>()))
+                diode::fill_alpha_shapes2d(ArrayWrapper<float>(a), AddSimplex(&filtration));
+            else if (a.dtype().is(py::dtype::of<double>()))
+                diode::fill_alpha_shapes2d(ArrayWrapper<double>(a), AddSimplex(&filtration));
+            else
+                throw std::runtime_error("Unknown array dtype");
+            sort_filtration(filtration);
+            return py::cast(filtration);
+        }
     }
     else
         throw std::runtime_error("Can only handle 2D or 3D alpha shapes");
 }
 
-AddSimplex::Simplices
-fill_weighted_alpha_shape(py::array a, bool exact)
+py::object
+fill_weighted_alpha_shape(py::array a, bool exact, bool with_attachment)
 {
+    if (with_attachment)
+    {
+        PyErr_SetString(PyExc_NotImplementedError,
+                        "with_attachment is not yet supported for weighted alpha shapes");
+        throw py::error_already_set();
+    }
+
     if (a.ndim() != 2)
         throw std::runtime_error("Unknown input dimension: can only process 2D arrays");
 
@@ -117,7 +177,7 @@ fill_weighted_alpha_shape(py::array a, bool exact)
                 diode::AlphaShapes<true>::fill_weighted_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration));
             else
                 diode::AlphaShapes<false>::fill_weighted_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration));
-            return filtration;
+            return py::cast(filtration);
         }
         else if (a.dtype().is(py::dtype::of<double>()))
         {
@@ -126,7 +186,7 @@ fill_weighted_alpha_shape(py::array a, bool exact)
                 diode::AlphaShapes<true>::fill_weighted_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration));
             else
                 diode::AlphaShapes<false>::fill_weighted_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration));
-            return filtration;
+            return py::cast(filtration);
         }
         else
             throw std::runtime_error("Unknown array dtype");
@@ -135,9 +195,16 @@ fill_weighted_alpha_shape(py::array a, bool exact)
         throw std::runtime_error("Can only handle 3D alpha shapes (input must be a 4-column array: coordinates + weight)");
 }
 
-AddSimplex::Simplices
-fill_periodic_alpha_shape(py::array a, bool exact, std::vector<double> from_, std::vector<double> to_)
+py::object
+fill_periodic_alpha_shape(py::array a, bool exact, std::vector<double> from_, std::vector<double> to_, bool with_attachment)
 {
+    if (with_attachment)
+    {
+        PyErr_SetString(PyExc_NotImplementedError,
+                        "with_attachment is not yet supported for periodic alpha shapes");
+        throw py::error_already_set();
+    }
+
     if (a.ndim() != 2)
         throw std::runtime_error("Unknown input dimension: can only process 2D arrays");
 
@@ -153,7 +220,7 @@ fill_periodic_alpha_shape(py::array a, bool exact, std::vector<double> from_, st
                 diode::AlphaShapes<true>::fill_periodic_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration), from, to);
             else
                 diode::AlphaShapes<false>::fill_periodic_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration), from, to);
-            return filtration;
+            return py::cast(filtration);
         }
         else if (a.dtype().is(py::dtype::of<double>()))
         {
@@ -162,7 +229,7 @@ fill_periodic_alpha_shape(py::array a, bool exact, std::vector<double> from_, st
                 diode::AlphaShapes<true>::fill_periodic_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration), from, to);
             else
                 diode::AlphaShapes<false>::fill_periodic_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration), from, to);
-            return filtration;
+            return py::cast(filtration);
         }
         else
             throw std::runtime_error("Unknown array dtype");
@@ -181,16 +248,23 @@ fill_periodic_alpha_shape(py::array a, bool exact, std::vector<double> from_, st
             throw std::runtime_error("Unknown array dtype");
 
         sort_filtration(filtration);
-        return filtration;
+        return py::cast(filtration);
     }
     else
         throw std::runtime_error("Can only handle 2D or 3D alpha shapes");
 }
 
 #if (CGAL_VERSION_MAJOR == 4 && CGAL_VERSION_MINOR >= 11) || (CGAL_VERSION_MAJOR > 4)
-AddSimplex::Simplices
-fill_weighted_periodic_alpha_shape(py::array a, bool exact, std::array<double,3> from, std::array<double,3> to)
+py::object
+fill_weighted_periodic_alpha_shape(py::array a, bool exact, std::array<double,3> from, std::array<double,3> to, bool with_attachment)
 {
+    if (with_attachment)
+    {
+        PyErr_SetString(PyExc_NotImplementedError,
+                        "with_attachment is not yet supported for weighted periodic alpha shapes");
+        throw py::error_already_set();
+    }
+
     if (a.ndim() != 2)
         throw std::runtime_error("Unknown input dimension: can only process 2D arrays");
 
@@ -203,7 +277,7 @@ fill_weighted_periodic_alpha_shape(py::array a, bool exact, std::array<double,3>
                 diode::AlphaShapes<true>::fill_weighted_periodic_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration), from, to);
             else
                 diode::AlphaShapes<false>::fill_weighted_periodic_alpha_shapes(ArrayWrapper<float>(a), AddSimplex(&filtration), from, to);
-            return filtration;
+            return py::cast(filtration);
         }
         else if (a.dtype().is(py::dtype::of<double>()))
         {
@@ -212,7 +286,7 @@ fill_weighted_periodic_alpha_shape(py::array a, bool exact, std::array<double,3>
                 diode::AlphaShapes<true>::fill_weighted_periodic_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration), from, to);
             else
                 diode::AlphaShapes<false>::fill_weighted_periodic_alpha_shapes(ArrayWrapper<double>(a), AddSimplex(&filtration), from, to);
-            return filtration;
+            return py::cast(filtration);
         }
         else
             throw std::runtime_error("Unknown array dtype");
@@ -260,22 +334,36 @@ PYBIND11_MODULE(diode, m)
 
     using namespace pybind11::literals;
     m.def("fill_alpha_shapes",  &fill_alpha_shape,
-          "data"_a, "exact"_a = false,
-          "returns (sorted) alpha shape filtration of the input points");
+          "data"_a, "exact"_a = false, "with_attachment"_a = false,
+          "Returns the (sorted) alpha shape filtration of the input points.\n"
+          "\n"
+          "If with_attachment=False (default), each entry is a pair\n"
+          "    (sigma_vertices, alpha)\n"
+          "where alpha is the filtration value of simplex sigma.\n"
+          "\n"
+          "If with_attachment=True, each entry is a triple\n"
+          "    (sigma_vertices, alpha, tau_vertices)\n"
+          "where tau_vertices are the vertices of a Gabriel coface tau of sigma\n"
+          "such that the squared circumradius of tau equals alpha. For Gabriel\n"
+          "sigma, tau == sigma. The triple form is intended for differentiable\n"
+          "alpha-filtration pipelines where alpha values must be expressed as\n"
+          "smooth functions of point coordinates.");
     m.def("fill_weighted_alpha_shapes",  &fill_weighted_alpha_shape,
-          "data"_a, "exact"_a = false,
-          "returns (sorted) alpha shape filtration of the weighted input points");
+          "data"_a, "exact"_a = false, "with_attachment"_a = false,
+          "returns (sorted) alpha shape filtration of the weighted input points (with_attachment=True is not yet supported)");
     m.def("fill_periodic_alpha_shapes",  &fill_periodic_alpha_shape,
           "data"_a, "exact"_a = false,
           "from"_a = std::vector<double> {0.,0.,0.},
           "to"_a   = std::vector<double> {1.,1.,1.},
-          "returns (sorted) alpha shape filtration of the input points on a periodic domain");
+          "with_attachment"_a = false,
+          "returns (sorted) alpha shape filtration of the input points on a periodic domain (with_attachment=True is not yet supported)");
 #if (CGAL_VERSION_MAJOR == 4 && CGAL_VERSION_MINOR >= 11) || (CGAL_VERSION_MAJOR > 4)
     m.def("fill_weighted_periodic_alpha_shapes",  &fill_weighted_periodic_alpha_shape,
           "data"_a, "exact"_a = false,
           "from"_a = std::array<double,3> {0.,0.,0.},
           "to"_a   = std::array<double,3> {1.,1.,1.},
-          "returns (sorted) alpha shape filtration of the weighted input points on a periodic domain");
+          "with_attachment"_a = false,
+          "returns (sorted) alpha shape filtration of the weighted input points on a periodic domain (with_attachment=True is not yet supported)");
 #endif
     m.def("circumcenter", &circumcenter, "points"_a, "exact"_a = false, "returns circumcenter of the intput points");
 }

--- a/include/diode/diode.h
+++ b/include/diode/diode.h
@@ -29,11 +29,26 @@
 namespace diode
 {
 
+// SimplexCallback contract:
+//   - For functions WITHOUT _with_attachment, the callback is invoked as
+//         add_simplex(sigma_vertices, alpha)
+//     where sigma_vertices is a std::array<unsigned, D> for D in {1,2,3,4}
+//     and alpha is a double (the filtration value).
+//   - For functions WITH _with_attachment, the callback is invoked as
+//         add_simplex(sigma_vertices, alpha, tau_vertices)
+//     where tau_vertices is a std::array<unsigned, D'> for D' in {1,2,3,4}
+//     listing the vertices of a simplex tau whose own squared circumradius
+//     (smallest enclosing sphere through tau's own vertices) equals alpha.
+//     For Gabriel sigma, tau == sigma. For non-Gabriel sigma, tau is a Gabriel
+//     coface of sigma.
 template<bool exact = false>
 struct AlphaShapes
 {
     template<class Points, class SimplexCallback>
     static void fill_alpha_shapes(const Points& points, const SimplexCallback& add_simplex);
+
+    template<class Points, class SimplexCallback>
+    static void fill_alpha_shapes_with_attachment(const Points& points, const SimplexCallback& add_simplex);
 
     template<class Points, class SimplexCallback>
     static void fill_weighted_alpha_shapes(const Points& points, const SimplexCallback& add_simplex);
@@ -55,6 +70,9 @@ struct AlphaShapes
 
 template<class Points, class SimplexCallback>
 void fill_alpha_shapes2d(const Points& points, const SimplexCallback& add_simplex);
+
+template<class Points, class SimplexCallback>
+void fill_alpha_shapes2d_with_attachment(const Points& points, const SimplexCallback& add_simplex);
 
 template<class Points, class SimplexCallback>
 void fill_periodic_alpha_shapes2d(const Points& points, const SimplexCallback& add_simplex,

--- a/include/diode/diode.hpp
+++ b/include/diode/diode.hpp
@@ -33,6 +33,150 @@ struct AlphaShapeWrapper
     using FT         = typename AlphaShape::FT;
     using PointsMap  = std::map<Point, Vertex>;
 
+    // Helpers: build the vertex list of a CGAL simplex (cell/facet/edge/vertex).
+    static std::vector<Vertex> verts_of_cell(typename AlphaShape::Cell_handle c, const PointsMap& points)
+    {
+        std::vector<Vertex> vs(4);
+        for (size_t i = 0; i < 4; ++i)
+            vs[i] = points.find(c->vertex(i)->point())->second;
+        return vs;
+    }
+
+    static std::vector<Vertex> verts_of_facet(const typename AlphaShape::Facet& f, const PointsMap& points)
+    {
+        std::vector<Vertex> vs;
+        vs.reserve(3);
+        typename AlphaShape::Cell_handle c = f.first;
+        for (size_t i = 0; i < 4; ++i)
+            if (static_cast<int>(i) != f.second)
+                vs.push_back(points.find(c->vertex(i)->point())->second);
+        return vs;
+    }
+
+    static std::vector<Vertex> verts_of_edge(const typename AlphaShape::Edge& e, const PointsMap& points)
+    {
+        typename AlphaShape::Cell_handle c = e.first;
+        std::vector<Vertex> vs(2);
+        vs[0] = points.find(c->vertex(e.second)->point())->second;
+        vs[1] = points.find(c->vertex(e.third)->point())->second;
+        return vs;
+    }
+
+    static std::vector<Vertex> verts_of_vertex(typename AlphaShape::Vertex_handle v, const PointsMap& points)
+    {
+        return std::vector<Vertex> { points.find(v->point())->second };
+    }
+
+    // Find a Gabriel coface tau of facet f such that squared_circumradius(tau) == alpha.
+    // For non-Gabriel facets, tau is one of the at-most-two adjacent finite cells.
+    static std::vector<Vertex> find_attacher_for_facet(
+        const typename AlphaShape::Facet& f,
+        const AlphaShape& as,
+        const FT& alpha,
+        const PointsMap& points)
+    {
+        auto fas = as.get_alpha_status(f);
+        if (fas.is_Gabriel())
+            return verts_of_facet(f, points);
+
+        typename AlphaShape::Cell_handle c0 = f.first;
+        typename AlphaShape::Cell_handle c1 = c0->neighbor(f.second);
+        if (!as.is_infinite(c0) && c0->get_alpha() == alpha)
+            return verts_of_cell(c0, points);
+        if (!as.is_infinite(c1) && c1->get_alpha() == alpha)
+            return verts_of_cell(c1, points);
+        throw std::runtime_error("find_attacher_for_facet: no matching coface");
+    }
+
+    // Find a Gabriel coface tau of edge e such that squared_circumradius(tau) == alpha.
+    // Search order: Gabriel facets (lower-dim) first, then incident cells.
+    static std::vector<Vertex> find_attacher_for_edge(
+        const typename AlphaShape::Edge& e,
+        const AlphaShape& as,
+        const FT& alpha,
+        const PointsMap& points)
+    {
+        auto eas = as.get_alpha_status(e);
+        if (eas.is_Gabriel())
+            return verts_of_edge(e, points);
+
+        typename AlphaShape::Cell_handle c = e.first;
+        int i = e.second;
+        int j = e.third;
+
+        // Gabriel facets first (they correspond to Gabriel-facet-contributions in compute_edge_status).
+        typename AlphaShape::Facet_circulator fcirc = as.incident_facets(c, i, j);
+        typename AlphaShape::Facet_circulator fdone = fcirc;
+        do {
+            if (!as.is_infinite(*fcirc)) {
+                auto fas_it = (*fcirc).first->get_facet_status((*fcirc).second);
+                if (fas_it->is_Gabriel() && fas_it->alpha_min() == alpha)
+                    return verts_of_facet(*fcirc, points);
+            }
+        } while (++fcirc != fdone);
+
+        // Then incident cells.
+        typename AlphaShape::Cell_circulator ccirc = as.incident_cells(c, i, j);
+        typename AlphaShape::Cell_circulator cdone = ccirc;
+        do {
+            if (!as.is_infinite(ccirc)) {
+                if (ccirc->get_alpha() == alpha)
+                    return verts_of_cell(ccirc, points);
+            }
+        } while (++ccirc != cdone);
+
+        throw std::runtime_error("find_attacher_for_edge: no matching coface");
+    }
+
+    // Find a Gabriel coface tau of vertex v such that squared_circumradius(tau) == alpha.
+    // For unweighted alpha shapes (Tag_false), every vertex is itself Gabriel and
+    // the search reduces to tau = v.
+    static std::vector<Vertex> find_attacher_for_vertex(
+        typename AlphaShape::Vertex_handle v,
+        const AlphaShape& as,
+        const FT& alpha,
+        const PointsMap& points)
+    {
+        // Fast path for the unweighted case: vertices are always Gabriel.
+        // Detected via is_Gabriel() to keep the helper safe in weighted/extended contexts.
+        auto* vas = v->get_alpha_status();
+        if (vas->is_Gabriel())
+            return verts_of_vertex(v, points);
+
+        // Weighted / general case: search incident Gabriel edges, then Gabriel facets,
+        // then incident cells. Lower-dim attacher preferred.
+        std::vector<typename AlphaShape::Edge> incident_es;
+        as.incident_edges(v, std::back_inserter(incident_es));
+        for (const auto& e : incident_es)
+        {
+            if (as.is_infinite(e)) continue;
+            auto eas = as.get_alpha_status(e);
+            if (eas.is_Gabriel() && eas.alpha_min() == alpha)
+                return verts_of_edge(e, points);
+        }
+
+        std::vector<typename AlphaShape::Facet> incident_fs;
+        as.incident_facets(v, std::back_inserter(incident_fs));
+        for (const auto& f : incident_fs)
+        {
+            if (as.is_infinite(f)) continue;
+            auto fas_it = f.first->get_facet_status(f.second);
+            if (fas_it->is_Gabriel() && fas_it->alpha_min() == alpha)
+                return verts_of_facet(f, points);
+        }
+
+        std::vector<typename AlphaShape::Cell_handle> incident_cs;
+        as.incident_cells(v, std::back_inserter(incident_cs));
+        for (auto c : incident_cs)
+        {
+            if (as.is_infinite(c)) continue;
+            if (c->get_alpha() == alpha)
+                return verts_of_cell(c, points);
+        }
+
+        throw std::runtime_error("find_attacher_for_vertex: no matching coface");
+    }
+
     // CGAL's peculiar design for its output of the alpha shape filtration requires
     // that once dereferenced this output iterator can be assigned both a
     // CGAL::Object and K::FT. The two are assigned in sequence. This requires
@@ -95,11 +239,86 @@ struct AlphaShapeWrapper
         CGAL::Object        o;
     };
 
+    // Output iterator that, in addition to the simplex and its alpha value,
+    // computes a Gabriel coface tau (the "attacher") and emits its vertex tuple.
+    // Callback signature: add_simplex(sigma_vertices, alpha, tau_vertices).
+    template<class AddSimplex>
+    struct ASOutputIterator3WithAttachment
+    {
+                          ASOutputIterator3WithAttachment(const AddSimplex& add_simplex_,
+                                                          const PointsMap& points_,
+                                                          const AlphaShape& as_):
+                              add_simplex(add_simplex_), points(points_), as(&as_) {}
+
+        ASOutputIterator3WithAttachment& operator*()                       { return *this; }
+        ASOutputIterator3WithAttachment& operator=(const CGAL::Object& o_) { o = o_; return *this; }
+        ASOutputIterator3WithAttachment& operator=(const FT& a)
+        {
+            using V = typename AlphaShape::Vertex_handle;
+            using E = typename AlphaShape::Edge;
+            using F = typename AlphaShape::Facet;
+            using C = typename AlphaShape::Cell_handle;
+
+            if (const V* v = CGAL::object_cast<V>(&o))
+            {
+                auto u = points.find((*v)->point())->second;
+                std::array<Vertex, 1> vertices { u };
+                auto tau = find_attacher_for_vertex(*v, *as, a, points);
+                add_simplex(vertices, to_floating_point(a), tau);
+            }
+            else if (const E* e = CGAL::object_cast<E>(&o))
+            {
+                C c = e->first;
+                auto u = points.find(c->vertex(e->second)->point())->second;
+                auto vv = points.find(c->vertex(e->third)->point())->second;
+                std::array<Vertex, 2> vertices { u, vv };
+                auto tau = find_attacher_for_edge(*e, *as, a, points);
+                add_simplex(vertices, to_floating_point(a), tau);
+            }
+            else if (const F* f = CGAL::object_cast<F>(&o))
+            {
+                std::array<Vertex, 3> vertices;
+                size_t j = 0;
+                C c = f->first;
+                for (size_t i = 0; i < 4; ++i)
+                    if (i != f->second)
+                        vertices[j++] = points.find(c->vertex(i)->point())->second;
+                auto tau = find_attacher_for_facet(*f, *as, a, points);
+                add_simplex(vertices, to_floating_point(a), tau);
+            } else if (const C* c = CGAL::object_cast<C>(&o))
+            {
+                std::array<Vertex, 4> vertices;
+                for (size_t i = 0; i < 4; ++i)
+                    vertices[i] = points.find((*c)->vertex(i)->point())->second;
+                auto tau = verts_of_cell(*c, points);   // cells are always Gabriel
+                add_simplex(vertices, to_floating_point(a), tau);
+            } else
+                throw std::runtime_error("Unknown object type in ASOutputIterator3WithAttachment");
+
+            return *this;
+        }
+
+        ASOutputIterator3WithAttachment& operator++()                      { return *this; }
+        ASOutputIterator3WithAttachment& operator++(int)                   { return *this; }
+
+        const AddSimplex&   add_simplex;
+        const PointsMap&    points;
+        const AlphaShape*   as;
+        CGAL::Object        o;
+    };
+
     template<class AddSimplex>
     static void fill_filtration(Delaunay& dt, const PointsMap& points_map, const AddSimplex& add_simplex)
     {
         AlphaShape as(dt, std::numeric_limits<FT>::infinity(), AlphaShape::GENERAL);
         as.filtration_with_alpha_values(ASOutputIterator3<AddSimplex>(add_simplex, points_map));
+    }
+
+    template<class AddSimplex>
+    static void fill_filtration_with_attachment(Delaunay& dt, const PointsMap& points_map, const AddSimplex& add_simplex)
+    {
+        AlphaShape as(dt, std::numeric_limits<FT>::infinity(), AlphaShape::GENERAL);
+        as.filtration_with_alpha_values(ASOutputIterator3WithAttachment<AddSimplex>(add_simplex, points_map, as));
     }
 };
 
@@ -136,6 +355,36 @@ fill_alpha_shapes(const Points& points, const SimplexCallback& add_simplex)
     auto points_range = points_map | boost::adaptors::map_keys;
     Delaunay dt(std::begin(points_range), std::end(points_range));
     ASWrapper::fill_filtration(dt, points_map, add_simplex);
+}
+
+template<bool exact>
+template<class Points, class SimplexCallback>
+void
+diode::AlphaShapes<exact>::
+fill_alpha_shapes_with_attachment(const Points& points, const SimplexCallback& add_simplex)
+{
+    using K          = detail::Kernel<exact>;
+    using Vb         = CGAL::Alpha_shape_vertex_base_3<K>;
+    using Fb         = CGAL::Alpha_shape_cell_base_3<K>;
+    using TDS        = CGAL::Triangulation_data_structure_3<Vb,Fb>;
+    using Delaunay   = CGAL::Delaunay_triangulation_3<K,TDS,CGAL::Fast_location>;
+
+    using ASWrapper  = detail::AlphaShapeWrapper<Delaunay>;
+    using PointsMap  = typename ASWrapper::PointsMap;
+    using AlphaShape = typename ASWrapper::AlphaShape;
+    using Vertex     = typename ASWrapper::Vertex;
+    using Point      = typename ASWrapper::Point;
+
+    PointsMap points_map;
+    for (Vertex i = 0; i < points.size(); ++i)
+    {
+        Point p(points(i,0), points(i,1), points(i,2));
+        points_map[p] = i;
+    }
+
+    auto points_range = points_map | boost::adaptors::map_keys;
+    Delaunay dt(std::begin(points_range), std::end(points_range));
+    ASWrapper::fill_filtration_with_attachment(dt, points_map, add_simplex);
 }
 
 template<bool exact>
@@ -471,6 +720,200 @@ fill_alpha_shapes2d(const Points& points, const SimplexCallback& add_simplex)
         {
             std::array<unsigned, 3> vertices { s[0], s[1], s[2] };
             add_simplex(vertices, s.value);
+        }
+    }
+}
+
+
+// Variant that emits attacher info for each simplex.
+// Callback signature: add_simplex(sigma_verts, alpha, tau_verts).
+// For Gabriel sigma, tau == sigma. For non-Gabriel sigma, tau is a Gabriel
+// coface whose own squared circumradius equals alpha.
+template<class Points, class SimplexCallback>
+void
+diode::
+fill_alpha_shapes2d_with_attachment(const Points& points, const SimplexCallback& add_simplex)
+{
+    using K             = CGAL::Exact_predicates_exact_constructions_kernel;
+    using Delaunay2D    = CGAL::Delaunay_triangulation_2<K>;
+    using Vertex_handle = Delaunay2D::Vertex_handle;
+    using Point         = Delaunay2D::Point;
+    using Face_handle   = Delaunay2D::Face_handle;
+
+    using ASPointMap    = std::unordered_map<Vertex_handle, unsigned>;
+
+    Delaunay2D  Dt;
+    ASPointMap  point_map;
+    for (unsigned i = 0; i < points.size(); ++i)
+    {
+        auto x = points(i,0);
+        auto y = points(i,1);
+        point_map[Dt.insert(Point(x,y))] = i;
+    }
+
+    // Same Simplex2D as the no-attachment version, plus attacher fields:
+    //   attacher_dim:     0 (vertex), 1 (edge), 2 (face)
+    //   attacher_vertices: meaningful prefix of length attacher_dim + 1
+    struct Simplex2D: public std::array<unsigned, 3>
+    {
+        double value;
+        unsigned dimension;
+        unsigned attacher_dim;
+        std::array<unsigned, 3> attacher_vertices;
+
+        void sort() { std::sort(begin(), begin() + dimension + 1); }
+
+        bool operator<(const Simplex2D& s) const
+        {
+            if (dimension < s.dimension) return true;
+            if (dimension == s.dimension)
+                return std::lexicographical_compare(begin(), begin() + dimension + 1, s.begin(), s.begin() + dimension + 1);
+
+            return false;
+        }
+
+
+        bool operator==(const Simplex2D& s) const
+        {
+            if (dimension != s.dimension)
+                return false;
+            for (unsigned i = 0; i < dimension + 1; ++i)
+                if ((*this)[i] != s[i])
+                    return false;
+            return true;
+        }
+    };
+
+    auto simplex_from_face = [&](const Delaunay2D::Face& f)
+    {
+        Simplex2D s;
+
+        s.dimension = 2;
+        for (int i = 0; i < 3; ++i) s[i] = point_map[f.vertex(i)];
+        auto p1    = f.vertex(0)->point();
+        auto p2    = f.vertex(1)->point();
+        auto p3    = f.vertex(2)->point();
+        auto alpha = CGAL::squared_radius(p1, p2, p3);
+        s.value = detail::to_floating_point(alpha);
+
+        // Faces are always self-attaching (their own squared circumradius
+        // is what defines their alpha value).
+        s.attacher_dim = 2;
+        s.attacher_vertices = { s[0], s[1], s[2] };
+
+        s.sort();
+
+        return s;
+    };
+
+    std::set<Simplex2D> simplices;
+
+    // faces
+    for(auto cur = Dt.finite_faces_begin(); cur != Dt.finite_faces_end(); ++cur)
+    {
+        Simplex2D s = simplex_from_face(*cur);
+        simplices.emplace(s);
+    }
+
+    // edges
+    for(auto cur = Dt.finite_edges_begin(); cur != Dt.finite_edges_end(); ++cur)
+    {
+        auto e = *cur;
+        Simplex2D s; s.dimension = 1;
+
+        std::array<Point,2> points;
+        unsigned j = 0;
+        Face_handle f = e.first;
+        for (int i = 0; i < 3; ++i)
+            if (i != e.second)
+            {
+                points[j] = f->vertex(i)->point();
+                s[j++] = point_map[f->vertex(i)];
+            }
+        auto& p1 = points[0];
+        auto& p2 = points[1];
+
+        // Default: edge is its own attacher (Gabriel case).
+        s.attacher_dim = 1;
+        s.attacher_vertices = { s[0], s[1], 0 };
+
+        Face_handle o = f->neighbor(e.second);
+        if (o == Face_handle())
+        {
+            s.value = detail::to_floating_point(CGAL::squared_radius(p1, p2));
+        } else
+        {
+            int oi = o->index(f);
+
+            bool attached = false;
+            if (!Dt.is_infinite(f->vertex(e.second)) &&
+                CGAL::side_of_bounded_circle(p1, p2,
+                                             f->vertex(e.second)->point()) == CGAL::ON_BOUNDED_SIDE)
+                attached = true;
+            else if (!Dt.is_infinite(o->vertex(oi)) &&
+                     CGAL::side_of_bounded_circle(p1, p2,
+                                                  o->vertex(oi)->point()) == CGAL::ON_BOUNDED_SIDE)
+                attached = true;
+            else
+                s.value = detail::to_floating_point(CGAL::squared_radius(p1, p2));
+
+            if (attached)
+            {
+                Simplex2D winning_face;
+                if (Dt.is_infinite(f))
+                    winning_face = *simplices.find(simplex_from_face(*o));
+                else if (Dt.is_infinite(o))
+                    winning_face = *simplices.find(simplex_from_face(*f));
+                else
+                {
+                    Simplex2D sf = *simplices.find(simplex_from_face(*f));
+                    Simplex2D so = *simplices.find(simplex_from_face(*o));
+                    winning_face = (sf.value <= so.value) ? sf : so;
+                }
+                s.value = winning_face.value;
+                s.attacher_dim = 2;
+                s.attacher_vertices = winning_face.attacher_vertices;
+            }
+        }
+
+        s.sort();
+        simplices.emplace(s);
+    }
+
+    // vertices: always Gabriel for unweighted alpha shapes (alpha = 0); tau = vertex itself.
+    for(auto cur = Dt.finite_vertices_begin(); cur != Dt.finite_vertices_end(); ++cur)
+    {
+        Simplex2D s;
+
+        s.dimension = 0;
+        s.value = 0;
+        for (int i = 0; i < 3; ++i)
+            if (cur->face()->vertex(i) != Vertex_handle() && cur->face()->vertex(i)->point() == cur->point())
+                s[0] = point_map[cur->face()->vertex(i)];
+
+        s.attacher_dim = 0;
+        s.attacher_vertices = { s[0], 0, 0 };
+
+        simplices.emplace(s);
+    }
+
+    // invoke callback with the simplices
+    for (auto& s : simplices)
+    {
+        std::vector<unsigned> tau_verts(s.attacher_vertices.begin(),
+                                        s.attacher_vertices.begin() + s.attacher_dim + 1);
+        if (s.dimension == 0)
+        {
+            std::array<unsigned, 1> vertices { s[0] };
+            add_simplex(vertices, s.value, tau_verts);
+        } else if (s.dimension == 1)
+        {
+            std::array<unsigned, 2> vertices { s[0], s[1] };
+            add_simplex(vertices, s.value, tau_verts);
+        } else if (s.dimension == 2)
+        {
+            std::array<unsigned, 3> vertices { s[0], s[1], s[2] };
+            add_simplex(vertices, s.value, tau_verts);
         }
     }
 }

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -61,4 +61,242 @@ def test_periodic():
         f = diode.fill_periodic_alpha_shapes(points)
 
         assert(is_sorted(f, key = lambda x: (x[1], len(x[0]))))
-    
+
+
+# ---- with_attachment tests --------------------------------------------------
+
+def _circumradius_squared(point_coords):
+    """Squared circumradius of a simplex from its vertex coordinates.
+
+    point_coords: (k, d) array, k in {1,2,3,4}, d in {2,3}.
+    Returns the squared smallest enclosing sphere through all k points,
+    matching CGAL's squared_radius for the same inputs.
+    """
+    pc = np.asarray(point_coords, dtype=np.float64)
+    k, d = pc.shape
+    if k == 1:
+        return 0.0
+    if k == 2:
+        return 0.25 * np.sum((pc[0] - pc[1]) ** 2)
+    if k == 3:
+        # Circumradius of a triangle in 2D or 3D.
+        a = pc[1] - pc[0]
+        b = pc[2] - pc[0]
+        a2 = np.dot(a, a)
+        b2 = np.dot(b, b)
+        ab = np.dot(a, b)
+        denom = 2.0 * (a2 * b2 - ab * ab)
+        if denom == 0:
+            raise ValueError("degenerate triangle")
+        # Bary coords of circumcenter relative to p0.
+        ca = (b2 * (a2 - ab)) / denom
+        cb = (a2 * (b2 - ab)) / denom
+        center_offset = ca * a + cb * b
+        return float(np.dot(center_offset, center_offset))
+    if k == 4:
+        # Circumradius of a tetrahedron in 3D.
+        a = pc[1] - pc[0]
+        b = pc[2] - pc[0]
+        c = pc[3] - pc[0]
+        a2 = np.dot(a, a)
+        b2 = np.dot(b, b)
+        c2 = np.dot(c, c)
+        # Solve the 3x3 system M x = rhs where M rows are 2*<a,b,c> dotted with x
+        M = 2.0 * np.array([[np.dot(a, a), np.dot(a, b), np.dot(a, c)],
+                            [np.dot(a, b), np.dot(b, b), np.dot(b, c)],
+                            [np.dot(a, c), np.dot(b, c), np.dot(c, c)]])
+        rhs = np.array([a2, b2, c2])
+        bary = np.linalg.solve(M, rhs)
+        center_offset = bary[0] * a + bary[1] * b + bary[2] * c
+        return float(np.dot(center_offset, center_offset))
+    raise ValueError(f"unexpected simplex size {k}")
+
+
+def test_cube_attachment_shapes():
+    points = np.array([[0.,0.,0.],
+                       [0.,0.,1.],
+                       [0.,1.,0.],
+                       [1.,0.,0.]])
+    f = diode.fill_alpha_shapes(points, with_attachment=True)
+
+    # Every entry is a 3-tuple.
+    for entry in f:
+        assert len(entry) == 3
+        sigma, alpha, tau = entry
+        assert isinstance(sigma, list)
+        assert isinstance(tau, list)
+        assert isinstance(alpha, float)
+        assert 1 <= len(sigma) <= 4
+        assert 1 <= len(tau) <= 4
+        assert len(tau) >= len(sigma)
+
+
+def test_cube_attachment_recompute():
+    points = np.array([[0.,0.,0.],
+                       [0.,0.,1.],
+                       [0.,1.,0.],
+                       [1.,0.,0.]])
+    f = diode.fill_alpha_shapes(points, with_attachment=True)
+
+    for sigma, alpha, tau in f:
+        recomputed = _circumradius_squared(points[tau])
+        assert abs(alpha - recomputed) < 1e-12, \
+            f"sigma={sigma}, alpha={alpha}, tau={tau}, recomputed={recomputed}"
+
+
+def test_cube_attachment_specific():
+    points = np.array([[0.,0.,0.],
+                       [0.,0.,1.],
+                       [0.,1.,0.],
+                       [1.,0.,0.]])
+    f = diode.fill_alpha_shapes(points, with_attachment=True)
+
+    # Build a lookup by sorted sigma vertex tuple.
+    by_sigma = { tuple(sorted(sigma)): (alpha, sorted(tau)) for sigma, alpha, tau in f }
+
+    # Vertices: alpha=0, tau == sigma.
+    for v in [0, 1, 2, 3]:
+        alpha, tau = by_sigma[(v,)]
+        assert alpha == 0.0
+        assert tau == [v]
+
+    # Short edges (length 1): alpha=0.25, Gabriel, tau == sigma.
+    for short_edge in [(0, 1), (0, 2), (0, 3)]:
+        alpha, tau = by_sigma[short_edge]
+        assert abs(alpha - 0.25) < 1e-12
+        assert tuple(tau) == short_edge
+
+    # Long edges (length sqrt(2)): alpha=0.5. For this configuration the
+    # third tetrahedron vertex lies exactly on the edge's MEB boundary, so
+    # CGAL classifies these edges as Gabriel and the recompute is trivially
+    # consistent with tau == sigma.
+    for long_edge in [(1, 2), (1, 3), (2, 3)]:
+        alpha, tau = by_sigma[long_edge]
+        assert abs(alpha - 0.5) < 1e-12
+        # tau must be a Gabriel coface whose own squared circumradius equals 0.5.
+        recomputed = _circumradius_squared(points[tau])
+        assert abs(alpha - recomputed) < 1e-12
+        # Both endpoints of the edge must be vertices of tau.
+        assert long_edge[0] in tau and long_edge[1] in tau
+
+    # Three Gabriel facets {0,1,2}, {0,1,3}, {0,2,3}: alpha=0.5, tau == sigma.
+    for f3 in [(0, 1, 2), (0, 1, 3), (0, 2, 3)]:
+        alpha, tau = by_sigma[f3]
+        assert abs(alpha - 0.5) < 1e-12
+        assert tuple(tau) == f3
+
+    # Non-Gabriel facet {1,2,3}: alpha=0.75, tau == cell {0,1,2,3}.
+    alpha, tau = by_sigma[(1, 2, 3)]
+    assert abs(alpha - 0.75) < 1e-12
+    assert tuple(tau) == (0, 1, 2, 3)
+
+    # Cell {0,1,2,3}: alpha=0.75, tau == sigma.
+    alpha, tau = by_sigma[(0, 1, 2, 3)]
+    assert abs(alpha - 0.75) < 1e-12
+    assert tuple(tau) == (0, 1, 2, 3)
+
+
+def _close(a, b, rtol=1e-7, atol=1e-9):
+    """Hybrid relative/absolute tolerance.
+
+    Random Delaunay configurations contain near-flat tetrahedra with huge
+    circumradii where the linear-algebra recompute and CGAL's geometric
+    formula can diverge by several units in the last few digits of a large
+    value. The user's downstream PyTorch implementation will use a different
+    formula too, so we validate approximate agreement, not bit-equality.
+    """
+    return abs(a - b) <= atol + rtol * abs(a)
+
+
+def test_random_3d_attachment_recompute():
+    np.random.seed(42)
+    points = np.random.random((50, 3))
+    f = diode.fill_alpha_shapes(points, with_attachment=True)
+
+    for sigma, alpha, tau in f:
+        recomputed = _circumradius_squared(points[tau])
+        assert _close(alpha, recomputed), \
+            f"sigma={sigma}, alpha={alpha}, tau={tau}, recomputed={recomputed}, diff={alpha-recomputed}"
+
+
+def test_random_2d_attachment_recompute():
+    np.random.seed(7)
+    points = np.random.random((50, 2))
+    f = diode.fill_alpha_shapes(points, with_attachment=True)
+
+    for sigma, alpha, tau in f:
+        recomputed = _circumradius_squared(points[tau])
+        assert _close(alpha, recomputed), \
+            f"sigma={sigma}, alpha={alpha}, tau={tau}, recomputed={recomputed}, diff={alpha-recomputed}"
+
+
+def test_2d_obtuse_attachment():
+    # Obtuse triangle: longest edge (between 1 and 2) is non-Gabriel of the face.
+    points = np.array([[0., 0.],
+                       [3., 0.],
+                       [1., 0.5]])
+    f = diode.fill_alpha_shapes(points, with_attachment=True)
+
+    by_sigma = { tuple(sorted(sigma)): (alpha, sorted(tau)) for sigma, alpha, tau in f }
+
+    # Edge (1, 2) has the largest squared length 4 + 0.25 = 4.25; squared
+    # circumradius of the edge alone is 4.25 / 4 ~ 1.0625. The face's
+    # circumradius squared should be larger only if the triangle is acute.
+    # For this obtuse triangle, the longest edge is non-Gabriel within the face.
+    edge_long = (0, 1)
+    alpha_long, tau_long = by_sigma[edge_long]
+    # Verify recompute consistency regardless of attachment outcome.
+    recomputed = _circumradius_squared(points[tau_long])
+    assert abs(alpha_long - recomputed) < 1e-9
+
+
+def test_pair_form_unchanged():
+    # Backward compatibility: with_attachment=False (default) returns pairs.
+    points = np.array([[0.,0.,0.],
+                       [0.,0.,1.],
+                       [0.,1.,0.],
+                       [1.,0.,0.]])
+    f_pair = diode.fill_alpha_shapes(points)
+    f_pair_explicit = diode.fill_alpha_shapes(points, with_attachment=False)
+
+    for entry in f_pair:
+        assert len(entry) == 2
+    assert sorted(f_pair) == sorted(f_pair_explicit)
+
+
+def test_pair_and_triple_alpha_match():
+    # Pair-form alpha values must match triple-form alpha values for the
+    # same simplex. Also verifies sigma order is consistent.
+    points = np.array([[0.,0.,0.],
+                       [0.,0.,1.],
+                       [0.,1.,0.],
+                       [1.,0.,0.]])
+    f_pair = diode.fill_alpha_shapes(points)
+    f_triple = diode.fill_alpha_shapes(points, with_attachment=True)
+
+    by_sigma_pair = { tuple(sorted(sigma)): alpha for sigma, alpha in f_pair }
+    by_sigma_triple = { tuple(sorted(sigma)): alpha for sigma, alpha, _ in f_triple }
+    assert by_sigma_pair == by_sigma_triple
+
+
+def test_with_attachment_not_implemented_for_weighted():
+    points = np.array([[0.,0.,0., 0.0],
+                       [0.,0.,1., 0.0],
+                       [0.,1.,0., 0.0],
+                       [1.,0.,0., 0.0]])
+    try:
+        diode.fill_weighted_alpha_shapes(points, with_attachment=True)
+    except NotImplementedError:
+        return
+    raise AssertionError("expected NotImplementedError for weighted with_attachment=True")
+
+
+def test_with_attachment_not_implemented_for_periodic():
+    np.random.seed(1)
+    points = np.random.random((10, 3))
+    try:
+        diode.fill_periodic_alpha_shapes(points, with_attachment=True)
+    except NotImplementedError:
+        return
+    raise AssertionError("expected NotImplementedError for periodic with_attachment=True")
+


### PR DESCRIPTION
Add an opt-in form of fill_alpha_shapes (and weighted/periodic stubs) that, in addition to each simplex sigma and its alpha value, returns the vertex tuple of a Gabriel coface tau whose own squared circumradius equals alpha. For Gabriel sigma, tau == sigma; otherwise tau is found by walking sigma's cofaces (preferring lower-dim Gabriel ancestors) and matching alpha at the CGAL FT level.

This is the data needed downstream to express alpha-filtration values as smooth, differentiable PyTorch operations on the input point cloud: the user computes circumradius^2(tau.vertices) in PyTorch and that yields alpha(sigma) with correct gradients.

C++ entry points are added alongside the existing ones (no contract change for current C++ users). The Python bindings expose the new behavior via a default-False with_attachment kwarg; weighted and periodic variants raise NotImplementedError when the flag is set.